### PR TITLE
fix: sort bug accessing localstorage

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
   },
   "lint-staged": {
     "*.{ts,tsx,js,jsx}": [
-      "yarn lint:fix",
+      "yarn lint",
       "git add"
     ],
     "*.{ts,tsx,json,js,jsx,html,scss,css}": [

--- a/src/components/App/index.tsx
+++ b/src/components/App/index.tsx
@@ -51,21 +51,22 @@ const Inner = () => {
   const isProject = activePage === VIEW_TYPES.project
   const isProjects = activePage === VIEW_TYPES.projects
   const isTeam = activePage === VIEW_TYPES.modites
-//  let isGlobe = listOptions.view === 'globe'
+  //  let isGlobe = listOptions.view === 'globe'
   let isGlobe
   const showTabBar = isLoaded && (isProjects || (isTeam && !isGlobe)) && !isProject
 
   const updateGlobe = () => {
-    let listOptions;
-    try {
-      listOptions = JSON.parse(localStorage.getItem("list-options"))
-    }
-    catch (e) {
+    let listOptions
+    const savedListOptions = localStorage.getItem('list-options')
+    if (savedListOptions) {
+      listOptions = JSON.parse(savedListOptions)
+    } else {
       listOptions = {
-        view: "list",
-        sort: "lasta",
+        view: 'list',
+        sort: 'lasta',
       }
     }
+
     isGlobe = listOptions.view === 'globe'
     setModiteListType(isGlobe ? 'globe' : 'list')
     if (isGlobe) {
@@ -186,16 +187,13 @@ const Inner = () => {
             <div className={s.title}>Modus Land</div>
             {isLoaded && isTeam ? (
               <>
-              <IonIcon
-                className={s.globeButton}
-                mode="ios"
-                name={moditeListType === 'globe' ? 'globe' : 'list'}
-                onClick={toggleListOptions}
-              />
-                <ListOptions
-                  isOpen={listOptionsPopover}
-                  onClose={toggleListOptions}
+                <IonIcon
+                  className={s.globeButton}
+                  mode="ios"
+                  name={moditeListType === 'globe' ? 'globe' : 'list'}
+                  onClick={toggleListOptions}
                 />
+                <ListOptions isOpen={listOptionsPopover} onClose={toggleListOptions} />
               </>
             ) : null}
           </div>

--- a/src/components/ListOptions/index.tsx
+++ b/src/components/ListOptions/index.tsx
@@ -1,24 +1,35 @@
 import * as React from 'react'
-import {IonPopover, IonIcon, IonToolbar, IonButtons, IonButton, IonList, IonListHeader, IonItem, IonLabel, IonRadioGroup, IonRadio} from '@ionic/react'
+import {
+  IonPopover,
+  IonIcon,
+  IonToolbar,
+  IonButtons,
+  IonButton,
+  IonList,
+  IonListHeader,
+  IonItem,
+  IonLabel,
+  IonRadioGroup,
+  IonRadio,
+} from '@ionic/react'
 import s from './styles.module.scss'
 
 const ListOptions: FunctionComponent = ({ isOpen, onClose }) => {
-  let options;
-  try {
-    options = JSON.parse(localStorage.getItem("list-options"))
-  }
-  catch (e) {
+  let options: { view: any; sort: any }
+
+  const savedOptions = localStorage.getItem('list-options')
+  if (savedOptions) {
+    options = JSON.parse(savedOptions)
+  } else {
     options = {
-      view: "list",
-      sort: "lasta",
+      view: 'list',
+      sort: 'lasta',
     }
   }
   const saveOptions = () => {
     try {
       localStorage.setItem('list-options', JSON.stringify(options))
-    }
-    catch (e) {
-    }
+    } catch (e) {}
   }
 
   const onApply = () => {
@@ -35,56 +46,37 @@ const ListOptions: FunctionComponent = ({ isOpen, onClose }) => {
   }
 
   const onViewAsChange = (e) => {
-    options.view = e.detail.value;
+    options.view = e.detail.value
   }
 
   const onSortByChange = (e) => {
-    options.sort = e.detail.value;
+    options.sort = e.detail.value
   }
 
   return (
-    <IonPopover
-      isOpen={isOpen}
-      backdropDismiss={false}
-    >
+    <IonPopover isOpen={isOpen} backdropDismiss={false}>
       <IonList>
         <IonItem>
-          <IonListHeader>
-            List Options
-          </IonListHeader>
+          <IonListHeader>List Options</IonListHeader>
         </IonItem>
 
-        <IonRadioGroup
-          value={options.view}
-          onIonChange = {onViewAsChange}
-        >
+        <IonRadioGroup value={options.view} onIonChange={onViewAsChange}>
           <IonListHeader>
             <IonLabel>View As</IonLabel>
           </IonListHeader>
           <IonItem>
-            <IonIcon
-              class={s.globeButton}
-              mode="ios"
-              name="list"
-            />
+            <IonIcon class={s.globeButton} mode="ios" name="list" />
             <IonLabel>List</IonLabel>
             <IonRadio slot="start" value="list" />
           </IonItem>
           <IonItem>
-            <IonIcon
-              class={s.globeButton}
-              mode="ios"
-              name="globe"
-            />
+            <IonIcon class={s.globeButton} mode="ios" name="globe" />
             <IonLabel>Globe</IonLabel>
             <IonRadio slot="start" value="globe" />
           </IonItem>
         </IonRadioGroup>
 
-        <IonRadioGroup
-          value={options.sort}
-          onIonChange = {onSortByChange}
-        >
+        <IonRadioGroup value={options.sort} onIonChange={onSortByChange}>
           <IonListHeader>
             <IonLabel>Sort By</IonLabel>
           </IonListHeader>
@@ -123,24 +115,17 @@ const ListOptions: FunctionComponent = ({ isOpen, onClose }) => {
         </IonRadioGroup>
       </IonList>
       <IonToolbar>
-          <IonButtons slot="end">
-          <IonButton
-            color="success"
-            onClick={onApply}
-          >
+        <IonButtons slot="end">
+          <IonButton color="success" onClick={onApply}>
             Apply
           </IonButton>
-          <IonButton
-            color="danger"
-            onClick={onCancel}
-          >
+          <IonButton color="danger" onClick={onCancel}>
             Cancel
           </IonButton>
-          </IonButtons>
-        </IonToolbar>
+        </IonButtons>
+      </IonToolbar>
     </IonPopover>
   )
 }
 
 export default React.memo(ListOptions)
-

--- a/src/hook/useModites.tsx
+++ b/src/hook/useModites.tsx
@@ -1,59 +1,59 @@
-import {ListOptions} from '../models/ListOptions.tsx'
+import { ListOptions } from '../models/ListOptions'
+import Modite from '../models/Modite'
 
-const useModites = (records) => {
-  let options:ListOptions
+const useModites = (records: Modite[]) => {
+  let options: ListOptions
 
-  try {
-    options = JSON.parse(localStorage.getItem("list-options"))
-  }
-  catch (e) {
+  const savedListOptions = localStorage.getItem('list-options')
+  if (savedListOptions) {
+    options = JSON.parse(savedListOptions)
+  } else {
     options = {
-      view: "list",
-      sort: "lasta",
+      view: 'list',
+      sort: 'lasta',
     }
   }
-
   let sort_records = [...records]
   switch (options.sort) {
-    case "lasta":
+    case 'lasta':
       break
-    case "lastd":
+    case 'lastd':
       sort_records = sort_records.reverse()
       break
-    case "firsta":
+    case 'firsta':
       sort_records.sort((a, b) => {
         const aFirst = a.real_name.split(' ').shift(),
           bFirst = b.real_name.split(' ').shift()
         return aFirst.localeCompare(bFirst)
       })
       break
-    case "firstd":
+    case 'firstd':
       sort_records.sort((a, b) => {
         const aFirst = a.real_name.split(' ').shift(),
           bFirst = b.real_name.split(' ').shift()
         return bFirst.localeCompare(aFirst)
       })
       break
-    case "tacosa":
+    case 'tacosa':
       sort_records.sort((a, b) => {
         return a.tacos - a.tacos
       })
       break
-    case "tacosd":
+    case 'tacosd':
       sort_records.sort((a, b) => {
         return b.tacos - a.tacos
       })
       break
-    case "timea":
+    case 'timea':
       sort_records.sort((a, b) => {
         return a.tz_offset - b.tz_offset
       })
       break
-    case "timed":
+    case 'timed':
       sort_records.sort((a, b) => {
         return b.tz_offset - a.tz_offset
       })
-      break;
+      break
   }
   return sort_records
 }


### PR DESCRIPTION
If you visit the deployed app https://dir.modus.app/ you will observe that it does not load, looking at the console log and you'll see there''s an error

```
scheduler.production.min.js:12 Uncaught TypeError: Cannot read property 'view' of null
    at ae (index.tsx:69)
    at index.tsx:79
    at Li (react-dom.production.min.js:262)
    at t.unstable_runWithPriority (scheduler.production.min.js:18)
    at Vl (react-dom.production.min.js:122)
    at Ni (react-dom.production.min.js:261)
    at di (react-dom.production.min.js:243)
    at react-dom.production.min.js:123
    at t.unstable_runWithPriority (scheduler.production.min.js:18)
    at Vl (react-dom.production.min.js:122)
```
    
 That is happening because of this line [here ](https://github.com/moduslabs/modir/blob/master/src/components/App/index.tsx#L60), the thing is that getting something from local storage returns either a string or null none of which will trigger the catch block, hence if localstorage is empty the value of `listOptions` will be null and the call on [Line 69 ](https://github.com/moduslabs/modir/blob/master/src/components/App/index.tsx#L69) will fail. 
    
 I have gone ahead to rewrite that logic and similar occurrences too.